### PR TITLE
Test: Add tests for Login and Signup requests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "python.testing.pytestArgs": [
-        "tests"
+        "tests",
+        "-s"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 from functools import lru_cache
 
@@ -9,17 +9,17 @@ class Settings(BaseSettings):
     base_dir: Path = Path(__file__).resolve().parent
     template_dir: Path = Path(__file__).resolve().parent / "templates"
     static_dir: Path = Path(__file__).resolve().parent / "static"
-    secret_key: str = Field(..., env="SECRET_KEY")
-    jwt_algorithm: str = Field(default="HS256", env="JWT_ALGORITHM")
-    token_expire: int = Field(default=86400, env="TOKEN_EXPIRE")
-    db_name: str = Field(..., env="DB_NAME")
-    db_server: str = Field(..., env="DB_SERVER")
-    db_username: str = Field(..., env="DB_USERNAME")
-    db_password: str = Field(..., env="DB_PASSWORD")
-    db_port: int = Field(..., env="DB_PORT")
 
-    class Config:
-        env_file = ".env"
+    secret_key: str = Field()
+    jwt_algorithm: str = Field(default="HS256")
+    token_expire: int = Field(default=86400)
+    db_name: str = Field()
+    db_server: str = Field()
+    db_username: str = Field()
+    db_password: str = Field()
+    db_port: int = Field()
+
+    model_config = SettingsConfigDict(env_file=".env", env_prefix="")
 
 
 @lru_cache

--- a/app/models.py
+++ b/app/models.py
@@ -1,8 +1,6 @@
 from .utils import validate_password
-from sqlalchemy import String
-from sqlalchemy.orm import Mapped, mapped_column
 from passlib.context import CryptContext
-from sqlmodel import Field, Session, SQLModel, create_engine, select
+from sqlmodel import Field, SQLModel
 from pydantic import (
     BaseModel,
     EmailStr,
@@ -12,7 +10,6 @@ from pydantic import (
     AfterValidator,
 )
 from typing import Optional, Annotated
-from typing_extensions import Self
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -35,7 +32,7 @@ class UserSignup(BaseModel):
 
 class User(SQLModel, table=True):
     __tablename__ = "USERS"
-    __table_args__ = {"schema": "auth"}
+    # __table_args__ = {"schema": "auth"}
 
     user_id: Optional[int] = Field(
         default=None,

--- a/app/routers/auth/users.py
+++ b/app/routers/auth/users.py
@@ -48,7 +48,7 @@ def login_user(
     if not user_account:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Account doesn't exist. Please try logging in again.",
+            detail="Invalid email or password. Please try logging in again.",
         )
 
     if not models.User.verify_password(

--- a/app/routers/auth/users.py
+++ b/app/routers/auth/users.py
@@ -91,7 +91,7 @@ def register_user(
     except ValidationError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"{e.errors()[0]['ctx']['error']}.",
+            detail=f"{e.errors()[0]['msg']}",
         ) from e
 
     if session.exec(

--- a/app/routers/auth/users.py
+++ b/app/routers/auth/users.py
@@ -25,7 +25,7 @@ class OAuth2PasswordSignupForm(OAuth2PasswordRequestForm):
         self.reconfirmPassword = reconfirmPassword
 
 
-@router.get("/login", response_class=HTMLResponse)
+@router.get("/login", response_class=HTMLResponse, name="login")
 def login_page(request: Request):
 
     return shortcuts.render(request, "/auth/login.html", status_code=200)
@@ -121,3 +121,9 @@ def register_user(
     )
 
     return shortcuts.redirect("/", cookies={"session_id": access_token})
+
+
+@router.get("/logout", response_class=HTMLResponse)
+def logout_page(request: Request):
+
+    return shortcuts.redirect("/", cookies={}, remove_session=True)

--- a/app/routers/auth/users.py
+++ b/app/routers/auth/users.py
@@ -28,7 +28,10 @@ class OAuth2PasswordSignupForm(OAuth2PasswordRequestForm):
 @router.get("/login", response_class=HTMLResponse, name="login")
 def login_page(request: Request):
 
-    return shortcuts.render(request, "/auth/login.html", status_code=200)
+    if "session_id" in request.cookies:
+        return shortcuts.redirect("/", cookies=request.cookies)
+    else:
+        return shortcuts.render(request, "/auth/login.html", status_code=200)
 
 
 @router.post("/login", response_class=HTMLResponse)
@@ -66,7 +69,10 @@ def login_user(
 @router.get("/signup", response_class=HTMLResponse)
 def signin_page(request: Request):
 
-    return shortcuts.render(request, "/auth/signup.html", status_code=200)
+    if "session_id" in request.cookies:
+        return shortcuts.redirect("/", cookies=request.cookies)
+    else:
+        return shortcuts.render(request, "/auth/signup.html", status_code=200)
 
 
 @router.post("/signup", response_class=HTMLResponse)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 
-{% block links %} {{super()}} {% endblock %}
+{% block links %} 
+    <li><a href="/">Home</a></li>
+    <li><a href="logout">Logout</a></li>
+{% endblock %}
 
 {% block content %}
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -62,8 +62,6 @@ def validate_password(v: SecretStr) -> SecretStr:
     if includes_special_chars and not any(
         char in special_chars for char in v.get_secret_value()
     ):
-        raise PasswordStrength(
-            f"Password should have at least one of the special symbols: {special_chars}"
-        )
+        raise PasswordStrength(f"Password should have at least one special character")
 
     return v

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ passlib[bcrypt]==1.7.4
 psycopg2==2.9.10
 sqlmodel==0.0.24
 pyjwt==2.10.1
+pytest==8.3.5

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_get_login_route():
+    """Test GET request to login route with no cookies"""
+    response = client.get("/login")
+    print(response.url)
+    assert response.status_code == 200
+    assert response.cookies == {}
+
+
+def test_get_login_route_with_session_cookie():
+    """Test GET request to login route with session_id cookie"""
+    test_client = TestClient(app, cookies={"session_id": "test_cookie"})
+    response = test_client.get("/login")
+    assert response.url == "http://testserver/"
+    assert response.status_code == 200
+
+
+def test_get_signup_route():
+    """Test GET request to signup route"""
+    response = client.get("/signup")
+    assert response.status_code == 200
+    assert response.cookies == {}
+
+
+def test_get_signup_route_with_session_cookie():
+    """Test GET request to signup route with session_id cookie"""
+    test_client = TestClient(app, cookies={"session_id": "test_cookie"})
+    response = test_client.get("/signup")
+    assert response.url == "http://testserver/"
+    assert response.status_code == 200

--- a/tests/test_auth_get_requests.py
+++ b/tests/test_auth_get_requests.py
@@ -2,12 +2,12 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 
-client = TestClient(app)
+base_client = TestClient(app)
 
 
 def test_get_login_route():
     """Test GET request to login route with no cookies"""
-    response = client.get("/login")
+    response = base_client.get("/login")
     print(response.url)
     assert response.status_code == 200
     assert response.cookies == {}
@@ -23,7 +23,7 @@ def test_get_login_route_with_session_cookie():
 
 def test_get_signup_route():
     """Test GET request to signup route"""
-    response = client.get("/signup")
+    response = base_client.get("/signup")
     assert response.status_code == 200
     assert response.cookies == {}
 

--- a/tests/test_auth_login_post_requests.py
+++ b/tests/test_auth_login_post_requests.py
@@ -1,0 +1,127 @@
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+from app.main import app
+from app.models import User
+import json
+from app.database import get_session
+import pytest
+
+base_client = TestClient(app)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(session: Session):
+    def get_session_override():
+        return session
+
+    app.dependency_overrides[get_session] = get_session_override
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+def test_successful_login_post_request(session: Session, client: TestClient):
+    """Test Succesful POST Request to login page"""
+    hashed_password = User.get_password_hash(password="Test123!")
+    user_account = User(email="test@gmail.com", password=hashed_password)
+    session.add(user_account)
+    session.commit()
+
+    response = client.post(
+        "/login",
+        data={
+            "username": "test@gmail.com",
+            "password": "Test123!",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert "session_id" in response.cookies
+
+
+def test_login_post_request(session: Session, client: TestClient):
+    """Test Succesful POST Request to login page"""
+    hashed_password = User.get_password_hash(password="Test123!")
+    user_account = User(email="test@gmail.com", password=hashed_password)
+    session.add(user_account)
+    session.commit()
+
+    response = client.post(
+        "/login",
+        data={
+            "username": "test@gmail.com",
+            "password": "Test123!",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert "session_id" in response.cookies
+
+
+def test_login_email_nonexistent_post_request(session: Session, client: TestClient):
+    """Test Failed POST Request to login page due to email not existing."""
+    account_email = "test2@gmail.com"
+    hashed_password = User.get_password_hash(password="Test123!")
+    user_account = User(email=account_email, password=hashed_password)
+    session.add(user_account)
+    session.commit()
+
+    response = client.post(
+        "/login",
+        data={
+            "username": "test1@gmail.com",
+            "password": "Test123!",
+        },
+        follow_redirects=False,
+    )
+
+    response_dict = response.json()
+
+    assert response.status_code == 401
+    assert (
+        response_dict["detail"]
+        == "Invalid email or password. Please try logging in again."
+    )
+
+
+def test_login_password_nonmatch_post_request(session: Session, client: TestClient):
+    """Test Failed POST Request to login page due to email not existing."""
+    account_email = "test@gmail.com"
+    hashed_password = User.get_password_hash(password="Test123!")
+    user_account = User(email=account_email, password=hashed_password)
+    session.add(user_account)
+    session.commit()
+
+    response = client.post(
+        "/login",
+        data={
+            "username": "test@gmail.com",
+            "password": "NonTest123!",
+        },
+        follow_redirects=False,
+    )
+
+    response_dict = response.json()
+
+    assert response.status_code == 401
+    assert (
+        response_dict["detail"]
+        == "Invalid email or password. Please try logging in again."
+    )

--- a/tests/test_auth_signup_post_requests.py
+++ b/tests/test_auth_signup_post_requests.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 from app.main import app
+import json
 from app.database import get_session
 import pytest
 
@@ -34,7 +35,7 @@ def client_fixture(session: Session):
 
 
 def test_successful_signup_post_request(client: TestClient):
-    """Test Succesfull POST Request to signup page"""
+    """Test Succesful POST Request to signup page"""
     response = client.post(
         "/signup",
         data={
@@ -42,6 +43,141 @@ def test_successful_signup_post_request(client: TestClient):
             "password": "Abcd123!",
             "reconfirmPassword": "Abcd123!",
         },
+        follow_redirects=False,
     )
-    print(response.status_code)
-    assert response.status_code == 200
+
+    assert response.status_code == 302
+    assert "session_id" in response.cookies
+
+
+def test_signup_invalid_email_post_request(client: TestClient):
+    """Test Failed POST Request to signup page from invalid email"""
+    response = client.post(
+        "/signup",
+        data={
+            "username": "testgmail.com",
+            "password": "Abcd123!",
+            "reconfirmPassword": "Abcd123!",
+        },
+    )
+    response_dict = response.json()
+
+    assert response.status_code == 400
+    assert (
+        response_dict["detail"]
+        == "value is not a valid email address: An email address must have an @-sign."
+    )
+
+
+def test_signup_password_length_le8_post_request(client: TestClient):
+    """Test Failed POST Request to signup page due to password less than 8 characters."""
+    response = client.post(
+        "/signup",
+        data={
+            "username": "test@gmail.com",
+            "password": "Abcd12!",
+            "reconfirmPassword": "Abcd12!",
+        },
+    )
+    response_dict = response.json()
+
+    assert response.status_code == 400
+    assert (
+        response_dict["detail"]
+        == "Value error, Password length should be at least 8 characters but not more than 20 characters"
+    )
+
+
+def test_signup_password_length_gr20_post_request(client: TestClient):
+    """Test Failed POST Request to signup page due to password more than 20 characters."""
+    response = client.post(
+        "/signup",
+        data={
+            "username": "test@gmail.com",
+            "password": "Abcdefghij1234567890!",
+            "reconfirmPassword": "Abcdefghij1234567890!",
+        },
+    )
+    response_dict = response.json()
+
+    assert response.status_code == 400
+    assert (
+        response_dict["detail"]
+        == "Value error, Password length should be at least 8 characters but not more than 20 characters"
+    )
+
+
+def test_signup_password_no_numbers_post_request(client: TestClient):
+    """Test Failed POST Request to signup page due to no numbers in password."""
+    response = client.post(
+        "/signup",
+        data={
+            "username": "test@gmail.com",
+            "password": "Abcdefg!",
+            "reconfirmPassword": "Abcdefg!",
+        },
+    )
+    response_dict = response.json()
+
+    assert response.status_code == 400
+    assert (
+        response_dict["detail"]
+        == "Value error, Password should have at least one numeral"
+    )
+
+
+def test_signup_password_no_uppercase_char_post_request(client: TestClient):
+    """Test Failed POST Request to signup page due to no uppercase characters in password."""
+    response = client.post(
+        "/signup",
+        data={
+            "username": "test@gmail.com",
+            "password": "abcdefg1!",
+            "reconfirmPassword": "abcdefg1!",
+        },
+    )
+    response_dict = response.json()
+
+    assert response.status_code == 400
+    assert (
+        response_dict["detail"]
+        == "Value error, Password should have at least one uppercase letter"
+    )
+
+
+def test_signup_password_no_lowercase_char_post_request(client: TestClient):
+    """Test Failed POST Request to signup page due to no lowercase characters in password."""
+    response = client.post(
+        "/signup",
+        data={
+            "username": "test@gmail.com",
+            "password": "ABCD123!",
+            "reconfirmPassword": "ABCD123!",
+        },
+    )
+    response_dict = response.json()
+
+    assert response.status_code == 400
+    assert (
+        response_dict["detail"]
+        == "Value error, Password should have at least one lowercase letter"
+    )
+
+
+def test_signup_password_no_special_char_post_request(client: TestClient):
+    """Test Failed POST Request to signup page due to no special characters in password."""
+    response = client.post(
+        "/signup",
+        data={
+            "username": "test@gmail.com",
+            "password": "Abcd1234",
+            "reconfirmPassword": "Abcd1234",
+        },
+    )
+    response_dict = response.json()
+
+    assert response.status_code == 400
+    assert (
+        response_dict["detail"]
+        == "Value error, Password should have at least one special character"
+    )

--- a/tests/test_auth_signup_post_requests.py
+++ b/tests/test_auth_signup_post_requests.py
@@ -1,0 +1,47 @@
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+from app.main import app
+from app.database import get_session
+import pytest
+
+base_client = TestClient(app)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(session: Session):
+    def get_session_override():
+        return session
+
+    app.dependency_overrides[get_session] = get_session_override
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+def test_successful_signup_post_request(client: TestClient):
+    """Test Succesfull POST Request to signup page"""
+    response = client.post(
+        "/signup",
+        data={
+            "username": "test@gmail.com",
+            "password": "Abcd123!",
+            "reconfirmPassword": "Abcd123!",
+        },
+    )
+    print(response.status_code)
+    assert response.status_code == 200

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_read_root_unathorized():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.cookies == {}


### PR DESCRIPTION
Added tests for Login and Signup routes including
 - Login Get Requests
 - Login Post Requests with Cookies
 - Signup Get Requests
 - Signup Post Requests with Cookies
 - Authenticated views of homepage (validating session_id cookie)

The coverage is 18 tests, constrained to only the authentication scope.

To run tests, run the following commands at the root directory within a virtual environment:
```
> pip install -r requirements.txt
> pytest -s
```